### PR TITLE
Fix bitwise operator

### DIFF
--- a/decompress_palmdoc.go
+++ b/decompress_palmdoc.go
@@ -13,7 +13,7 @@ func palmdoc_unpack(data []byte) string {
 		position += 1
 		if c >= 0xC0 {
 			buffer.WriteByte(' ')
-			buffer.WriteByte(byte(c) & 0x80)
+			buffer.WriteByte(byte(c) ^ 0x80)
 		} else if c >= 0x80 {
 			next := int(data[position])
 			position += 1


### PR DESCRIPTION
This should be xor per reference implementation in Calibre: http://bazaar.launchpad.net/~kovid/calibre/trunk/view/head:/src/calibre/ebooks/compression/palmdoc.c

This corrects bugs where the character after a space is often incorrect.